### PR TITLE
Add array_dot_rename function

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This implementation brings some custom syntax which will be explained bellow.
 
 array_dot_get(array $array, string $path) : mixed;
 array_dot_set(array $array, string $path, mixed $value) : mixed;
+array_dot_rename(array $array, string $path, string $newName) : mixed;
 array_dot_exists(array $array, string $path) : bool;
 array_dot_steps(string $path) : array;
 ```
@@ -102,6 +103,7 @@ Supported in functions:
 
 - `array_dot_get`
 - `array_dot_set`
+- `array_dot_rename`
 
 Wildcard operator allows to access all paths in nested arrays.
 

--- a/src/Flow/ArrayDot/array_dot.php
+++ b/src/Flow/ArrayDot/array_dot.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ArrayDot;
 
+use Flow\ArrayDot\Exception\Exception;
 use Flow\ArrayDot\Exception\InvalidPathException;
 
 /**
@@ -234,6 +235,81 @@ function array_dot_get(array $array, string $path)
     }
 
     return $arraySlice;
+}
+
+/**
+ * @param array<mixed> $array
+ * @param string $path
+ * @param string $newName
+ *
+ * @throws InvalidPathException
+ *
+ * @return array<mixed>
+ */
+function array_dot_rename(array $array, string $path, string $newName) : array
+{
+    if (!array_dot_exists($array, $path)) {
+        throw new InvalidPathException(
+            \sprintf(
+                'Path "%s" does not exists in array "%s".',
+                $path,
+                \preg_replace('/\s+/', '', \trim(\var_export($array, true)))
+            )
+        );
+    }
+
+    $pathSteps = array_dot_steps($path);
+    $lastStep = \array_pop($pathSteps);
+
+    $currentElement = &$array;
+
+    $takenSteps = [];
+
+    foreach ($pathSteps as $step) {
+        $takenSteps[] = $step;
+
+        if ($step === '*') {
+            /**
+             * @var array<mixed> $nestedValues
+             */
+            $nestedValues = array_dot_get($array, \implode('.', $takenSteps));
+            $stepsLeft = \array_slice($pathSteps, \count($takenSteps), \count($pathSteps));
+            \array_push($stepsLeft, $lastStep);
+
+            /** @var mixed $nestedValue */
+            foreach ($nestedValues as $nestedKey => $nestedValue) {
+                $currentElement[$nestedKey] = array_dot_rename((array) $nestedValue, \implode('.', $stepsLeft), $newName);
+            }
+
+            return $array;
+        }
+
+        if ($step == '\\*') {
+            $step = \str_replace('\\', '', $step);
+            \array_pop($takenSteps);
+            $takenSteps[] = $step;
+        }
+
+        if (!\is_array($currentElement[$step])) {
+            throw new Exception(
+                \sprintf(
+                    'Item for path "%s" is not an array in "%s".',
+                    \implode('.', $takenSteps),
+                    \preg_replace('/\s+/', '', \trim(\var_export($array, true)))
+                )
+            );
+        }
+
+        $currentElement = &$currentElement[$step];
+    }
+
+    /**
+     * @psalm-suppress MixedAssignment
+     */
+    $currentElement[$newName] = $currentElement[$lastStep];
+    unset($currentElement[$lastStep]);
+
+    return $array;
 }
 
 /**

--- a/tests/Flow/ArrayDot/Tests/Unit/ArrayDotRenameTest.php
+++ b/tests/Flow/ArrayDot/Tests/Unit/ArrayDotRenameTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ArrayDot\Tests\Unit;
+
+use function Flow\ArrayDot\array_dot_rename;
+use PHPUnit\Framework\TestCase;
+
+final class ArrayDotRenameTest extends TestCase
+{
+    public function test_renames_array_root_key_name() : void
+    {
+        $this->assertEquals(
+            [
+                'admins' => [
+                    ['id' => 1, 'name' => 'John'],
+                    ['id' => 2, 'date' => 'Paul'],
+                ],
+                'status' => 'active',
+            ],
+            array_dot_rename(
+                [
+                    'users' => [
+                        ['id' => 1, 'name' => 'John'],
+                        ['id' => 2, 'date' => 'Paul'],
+                    ],
+                    'status' => 'active',
+                ],
+                'users',
+                'admins'
+            )
+        );
+    }
+
+    public function test_renames_array_by_path() : void
+    {
+        $this->assertSame(
+            [
+                'users' => [
+                    ['id' => 1, 'user_name' => 'John'],
+                    ['id' => 2, 'name' => 'Paul'],
+                ],
+            ],
+            array_dot_rename(
+                [
+                    'users' => [
+                        ['id' => 1, 'name' => 'John'],
+                        ['id' => 2, 'name' => 'Paul'],
+                    ],
+                ],
+                'users.0.name',
+                'user_name'
+            )
+        );
+    }
+
+    public function test_renames_array_by_path_with_asterix() : void
+    {
+        $this->assertSame(
+            [
+                'users' => [
+                    ['id' => 1, 'user_name' => 'John'],
+                    ['id' => 2, 'user_name' => 'Paul'],
+                ],
+            ],
+            array_dot_rename(
+                [
+                    'users' => [
+                        ['id' => 1, 'name' => 'John'],
+                        ['id' => 2, 'name' => 'Paul'],
+                    ],
+                ],
+                'users.*.name',
+                'user_name'
+            )
+        );
+    }
+
+    public function test_renames_array_by_path_with_asterix_as_a_key() : void
+    {
+        $this->assertSame(
+            [
+                'users' => [
+                    'john' => ['id' => 1],
+                    'paul' => ['id' => 2],
+                    '*' => ['asterix_id' => 3],
+                ],
+            ],
+            array_dot_rename(
+                [
+                    'users' => [
+                        'john' => ['id' => 1],
+                        'paul' => ['id' => 2],
+                        '*' => ['id' => 3],
+                    ],
+                ],
+                'users.\\*.id',
+                'asterix_id'
+            )
+        );
+    }
+
+    public function test_renames_array_by_path_with_multiple_asterix() : void
+    {
+        $this->assertSame(
+            [
+                'transactions' => [
+                    [
+                        'id' => 1,
+                        'packages' => [
+                            [
+                                'label_id' => '12345',
+                            ],
+                            [
+                                'label_id' => '22222',
+                            ],
+                        ],
+                    ],
+                    [
+                        'id' => 2,
+                        'packages' => [
+                            [
+                                'label_id' => '3333',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            array_dot_rename(
+                [
+                    'transactions' => [
+                        [
+                            'id' => 1,
+                            'packages' => [
+                                [
+                                    'id' => '12345',
+                                ],
+                                [
+                                    'id' => '22222',
+                                ],
+                            ],
+                        ],
+                        [
+                            'id' => 2,
+                            'packages' => [
+                                [
+                                    'id' => '3333',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'transactions.*.packages.*.id',
+                'label_id'
+            ),
+        );
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
<li>Added function to rename array keys using dot notation</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>
It would be useful to allow renaming array keys using dot notation. 
